### PR TITLE
Remove DDOS scrubbing option.

### DIFF
--- a/changelogs/fragments/remove-ddos-scrubbing.yaml
+++ b/changelogs/fragments/remove-ddos-scrubbing.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - remove ddos_scrubbing option from the floating_ip module, since upstream API changes have made it unusable.

--- a/plugins/modules/floating_ip.py
+++ b/plugins/modules/floating_ip.py
@@ -65,12 +65,6 @@ options:
             - Relative DNS name for the IP address.
             - Resulting FQDN will be '<relative-dns-name>.cloud.cherryservers.net' and must be globally unique.
         type: str
-    ddos_scrubbing:
-        description:
-            - If true, DDOS scrubbing protection will be applied in real-time.
-            - Cannot be updated after creation.
-        default: false
-        type: bool
     tags:
         description:
             - Tags of the floating IP.
@@ -271,7 +265,6 @@ class FloatingIPModule(standard_module.StandardModule):
                 "targeted_to": params["target_server_id"],
                 "ptr_record": params["ptr_record"],
                 "a_record": params["a_record"],
-                "ddos_scrubbing": params["ddos_scrubbing"],
                 "tags": params["tags"],
             },
         )
@@ -307,7 +300,6 @@ class FloatingIPModule(standard_module.StandardModule):
             "target_server_id": {"type": "int"},
             "ptr_record": {"type": "str"},
             "a_record": {"type": "str"},
-            "ddos_scrubbing": {"type": "bool", "default": False},
             "tags": {
                 "type": "dict",
             },


### PR DESCRIPTION
Remove ddos_scrubbing optionf from the floating_ip module. Upstream API changes have made it unusable. Resolves https://github.com/cherryservers/ansible-collection-cherryservers/issues/7.