### PR TITLE
Wait for server deployment when reinstalling.

### DIFF
--- a/changelogs/fragments/wait-for-active-server-reinstall.yaml
+++ b/changelogs/fragments/wait-for-active-server-reinstall.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Wait for server to become active, if ``state`` is set to active, on server reinstall.

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -371,12 +371,12 @@ class ServerModule(standard_module.StandardModule):
         if requests.get("reinstall", None):
             if not params["allow_reinstall"]:
                 self._module.fail_json(msg="provided options require server reinstall")
-            self._server_manager.reinstall_server(
+            server = self._server_manager.reinstall_server(
                 resource["id"],
                 requests["reinstall"],
             )
             if params["state"] == "active":
-                self._server_manager.wait_for_active(resource, params["active_timeout"])
+                self._server_manager.wait_for_active(server, params["active_timeout"])
 
         if requests.get("basic", None):
             self._server_manager.update_server(resource["id"], requests["basic"])


### PR DESCRIPTION
Wait for server deployment when reinstalling,
if state is set to active. Resolves https://github.com/cherryservers/ansible-collection-cherryservers/issues/8.