### PR TITLE
Retain SSH key and OS image values on server re-install.

### DIFF
--- a/changelogs/fragments/retain-ssh-keys-and-images-on-server-reinstall.yaml
+++ b/changelogs/fragments/retain-ssh-keys-and-images-on-server-reinstall.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  -
+    On server reinstall, set SSH keys and images to their previous values,
+    if they haven't been changed or are unprovided.

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -360,6 +360,10 @@ class ServerModule(standard_module.StandardModule):
                 reinstall_req[k] = params[k]
 
         if reinstall_req:
+            if reinstall_req.get("ssh_keys", None) is None:
+                reinstall_req["ssh_keys"] = resource["ssh_keys"]
+            if reinstall_req.get("image", None) is None:
+                reinstall_req["image"] = resource["image"]
             reinstall_req["password"] = generate_password(16)
             reinstall_req["type"] = "reinstall"
             req["reinstall"] = reinstall_req


### PR DESCRIPTION
Resolves https://github.com/cherryservers/ansible-collection-cherryservers/issues/9.